### PR TITLE
Update check_model_parents_schema.py

### DIFF
--- a/dbt_checkpoint/check_model_parents_schema.py
+++ b/dbt_checkpoint/check_model_parents_schema.py
@@ -7,8 +7,9 @@ from dbt_checkpoint.tracking import dbtCheckpointTracking
 from dbt_checkpoint.utils import (
     JsonOpenError,
     add_default_args,
-    get_dbt_manifest,
     get_filenames,
+    get_json,
+    get_missing_file_paths,
     get_models,
     get_parent_childs,
 )
@@ -19,12 +20,16 @@ def check_parents_schema(
     manifest: Dict[str, Any],
     blacklist: Optional[Sequence[str]],
     whitelist: Optional[Sequence[str]],
+    schema_location: Optional[str],
 ) -> int:
+    paths = get_missing_file_paths(paths, manifest)
+
     status_code = 0
     sqls = get_filenames(paths, [".sql"])
     filenames = set(sqls.keys())
     blacklist = blacklist or []
     whitelist = whitelist or []
+    schema_location = schema_location or []
 
     # get manifest nodes that pre-commit found as changed
     models = get_models(manifest, filenames)
@@ -39,7 +44,13 @@ def check_parents_schema(
             )
         )
         for parent in parents:
-            db = parent.node.get("schema")
+            # Selecting the location of the model schema
+            if schema_location == "config": # pragma: no cover
+                # Chooses the schema inside in the model config (nodes -> model -> config -> schema)
+                db = parent.node.get("config").get("schema")
+            else: # pragma: no cover
+                # Chooses the schema outside the model config (nodes -> model -> schema)
+                db = parent.node.get("schema")
             if (whitelist and db not in whitelist) or db in blacklist:
                 status_code = 1
                 print(
@@ -68,10 +79,19 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         help="Blacklisted schemas.",
     )
 
+    parser.add_argument(
+        "--schema_location",
+        type=str,
+        nargs="?",
+        required=False,
+        default="",
+        help="Location of the model schema.",
+    ),
+
     args = parser.parse_args(argv)
 
     try:
-        manifest = get_dbt_manifest(args)
+        manifest = get_json(args.manifest)
     except JsonOpenError as e:
         print(f"Unable to load manifest file ({e})")
         return 1
@@ -86,6 +106,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         manifest=manifest,
         blacklist=args.blacklist,
         whitelist=args.whitelist,
+        schema_location=args.schema_location,
     )
     end_time = time.time()
     script_args = vars(args)


### PR DESCRIPTION
This PR copies the work of @kiliantscherny [here](https://github.com/dbt-checkpoint/dbt-checkpoint/pull/132). Below is a copy-paste of his PR description:

---
 I'm proposing a small change to the `check_model_parents_schema` check to fix an issue with the parsing of the parent models' schema.
 
 **Current state** When this check is run, it parses the `schema` from [nodes → schema](https://schemas.getdbt.com/dbt/manifest/v4/index.html#nodes_additionalProperties_oneOf_i0_schema), which is prefixed by an individual's configuration in `profiles.yml` – for example:
 
 For a BigQuery-based profile:
 
 ```
 [project_name]:
   outputs:
     dev:
       dataset: [dev_dataset_name]
 ...
 ```
 
 For a Snowflake-based profile:
 
 ```
 [project_name]:
   outputs:
     dev:
       ...
       schema: [dev_dataset_name]
 ...
 ```
 
 In `manifest.json`, for any given model, `nodes → schema` inherits the individual's `[dev_dataset_name]` and prefixes it in front of the "true" schema name, which itself comes from `dbt_project.yml`, e.g. for a "dim" folder in an example repo:
 
 ```
 models:
   [project_name]:
     +materialized: view
     ...
     dim:
       +materialized: table
       +schema: dim_schema_name
 ```
 
> This then causes the check to fail if we set the args as:
 
 ```
 - id: check-model-parents-schema
     args: ["--manifest", "analytics/target/manifest.json", "--whitelist", "dim_schema_name", "--"]
 ```
 
 Because the schema is parsed from `nodes → schema` as `dev_dim_schema_name` rather than `dim_schema_name` (which is found in `nodes → config → schema`), the check doesn't work as expected.
 
 **Proposed solution** In our organisation, we have had issues with this check because we actually need it to parse the schema from [nodes → config → schema](https://schemas.getdbt.com/dbt/manifest/v7/index.html#nodes_additionalProperties_oneOf_i0_config_schema) instead, as the different dbt developers each have their own dev dataset name which prefixes the model schema in their dev environment. This must have changed when the manifest was updated to a newer version.
 
 By selecting from the "nested" schema that's inside `config`, we get the "true" schema name reliably every time, for each developer and in production.
 
 The additional argument I'm adding to `args` is `--schema_location` to optionally specify if the intended schema is located inside `config`.
 
 **How it works** It's completely optional, and only requires the user to add `"--schema_location", "config"` to the `args` after the white-/blacklist argument, like:
 
 ```
 - id: check-model-parents-schema
     args: ["--manifest", "analytics/target/manifest.json", "--whitelist", "dim_schema_name",  "--schema_location", "config", "--"]
 ```
 
 **Note on testing coverage** I'm not really too familiar with Pytest or how to ensure complete coverage, so if there are any other contributors with an idea of how to help with this I'd be hugely grateful!

