### PR TITLE
Remove archiving message from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
-> :warning: This repository was archived automatically since no ownership was defined :warning:
->
-> For details on how to claim stewardship of this repository see:
->
-> [How to configure a service in OpsLevel](https://www.notion.so/pleo/How-to-configure-a-service-in-OpsLevel-f6483fcb4fdd4dcc9fc32b7dfe14c262)
->
-> To learn more about the automatic process for stewardship which archived this repository see:
->
-> [Automatic process for stewardship](https://www.notion.so/pleo/Automatic-process-for-stewardship-43d9def9bc9a4010aba27144ef31e0f2)
-
-
 # About this repository
 
 **Forked** from: https://github.com/dbt-checkpoint/dbt-checkpoint


### PR DESCRIPTION
Just removing the piece about archiving the repo that the grim repo bot added when it was archived recently.